### PR TITLE
Add PDF viewer skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# CodexPdfOne
+
+This project demonstrates integrating an open-source PDF engine in an Android application. It uses [AndroidPdfViewer](https://github.com/barteksc/AndroidPdfViewer) for rendering and pinch‑to‑zoom support and [PdfBox-Android](https://github.com/TomRoush/PdfBox-Android) for creating and manipulating PDF content.
+
+## Features
+
+- View PDF documents with smooth zooming and panning.
+- Freehand annotation overlay using `AnnotationView`.
+- Sample PDF bundled in the `assets` folder.
+- Ready to extend with form filling, signatures and image placement.
+
+## Running
+
+Build the project with Android Studio or the command line:
+
+```bash
+./gradlew assembleDebug
+```
+
+Then install the APK on a device or emulator.
+
+## Licensing
+
+Both AndroidPdfViewer and PdfBox-Android are Apache‑2.0 licensed, which allows commercial usage.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,6 +39,9 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    // PDF libraries for rendering and editing
+    implementation(libs.android.pdf.viewer)
+    implementation(libs.pdfbox.android)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".PdfActivity"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/app/src/main/assets/sample.pdf
+++ b/app/src/main/assets/sample.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 72 150 Td (Hello, PDF!) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000117 00000 n 
+0000000218 00000 n 
+0000000312 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+360
+%%EOF

--- a/app/src/main/java/com/example/codexpdfone/PdfActivity.kt
+++ b/app/src/main/java/com/example/codexpdfone/PdfActivity.kt
@@ -1,0 +1,43 @@
+package com.example.codexpdfone
+
+import android.net.Uri
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import com.github.barteksc.pdfviewer.PDFView
+import com.example.codexpdfone.ui.AnnotationView
+
+/**
+ * Activity that showcases PDF viewing with a simple annotation overlay.
+ * The PDF rendering is provided by AndroidPdfViewer (Pdfium based) which
+ * supports smooth zooming and panning. AnnotationView demonstrates how
+ * to capture freehand drawings that could later be converted into PDF
+ * annotations using a library like PdfBox-Android.
+ */
+class PdfActivity : AppCompatActivity() {
+
+    private lateinit var pdfView: PDFView
+    private lateinit var annotationView: AnnotationView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_pdf)
+
+        pdfView = findViewById(R.id.pdfView)
+        annotationView = findViewById(R.id.annotationView)
+
+        // Load a sample PDF from assets. In a real app this could come from
+        // external storage or be created dynamically.
+        val uri: Uri = Uri.parse("file:///android_asset/sample.pdf")
+        pdfView.fromUri(uri)
+            .enableAnnotationRendering(true)
+            .enableSwipe(true)
+            .swipeHorizontal(false)
+            .enableDoubletap(true)
+            .load()
+
+        // Allow user to draw over the PDF for annotations.
+        annotationView.drawingEnabled = true
+    }
+}

--- a/app/src/main/java/com/example/codexpdfone/ui/AnnotationView.kt
+++ b/app/src/main/java/com/example/codexpdfone/ui/AnnotationView.kt
@@ -1,0 +1,54 @@
+package com.example.codexpdfone.ui
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+
+/**
+ * Simple view used to draw freehand annotations over the PDF.
+ * This can be extended to support shapes and other annotation types.
+ */
+class AnnotationView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val paint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.RED
+        style = Paint.Style.STROKE
+        strokeWidth = 5f
+    }
+
+    private val path = Path()
+    var drawingEnabled: Boolean = false
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        if (!drawingEnabled) return false
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> path.moveTo(event.x, event.y)
+            MotionEvent.ACTION_MOVE -> path.lineTo(event.x, event.y)
+        }
+        invalidate()
+        return true
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        canvas.drawPath(path, paint)
+    }
+
+    /**
+     * Clears current annotations. In a full implementation the path data should
+     * be converted into PDF annotations using a library like PdfBox-Android.
+     */
+    fun clearAnnotations() {
+        path.reset()
+        invalidate()
+    }
+}

--- a/app/src/main/res/layout/activity_pdf.xml
+++ b/app/src/main/res/layout/activity_pdf.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.github.barteksc.pdfviewer.PDFView
+        android:id="@+id/pdfView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.example.codexpdfone.ui.AnnotationView
+        android:id="@+id/annotationView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ appcompat = "1.7.1"
 material = "1.12.0"
 activity = "1.10.1"
 constraintlayout = "2.2.1"
+androidPdfViewer = "3.3.0"
+pdfboxAndroid = "2.0.27.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -19,6 +21,8 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+android-pdf-viewer = { group = "com.github.barteksc", name = "android-pdf-viewer", version.ref = "androidPdfViewer" }
+pdfbox-android = { group = "com.tom-roush", name = "pdfbox-android", version.ref = "pdfboxAndroid" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- add AndroidPdfViewer and PdfBox-Android dependencies
- add `PdfActivity` and annotation overlay view
- add sample PDF asset and layout for viewing
- document setup in README

## Testing
- `./gradlew help` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6860512d1880832da9fa353458c0214e