### PR TITLE
Support multi-PDF scrolling and scalable annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## Features
 
-- View PDF documents with smooth zooming and panning.
-- Freehand annotation overlay using `AnnotationView`.
-- Sample PDF bundled in the `assets` folder.
+- View multiple PDF files in a scrollable list.
+- Pinch zoom gestures with annotations scaling appropriately.
+- Sample PDFs bundled in the `assets` folder.
 - Ready to extend with form filling, signatures and image placement.
 
 ## Running

--- a/app/src/main/java/com/example/codexpdfone/ui/AnnotationView.kt
+++ b/app/src/main/java/com/example/codexpdfone/ui/AnnotationView.kt
@@ -3,6 +3,7 @@ package com.example.codexpdfone.ui
 import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Color
+import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.Path
 import android.util.AttributeSet
@@ -27,12 +28,22 @@ class AnnotationView @JvmOverloads constructor(
 
     private val path = Path()
     var drawingEnabled: Boolean = false
+    private val matrix = Matrix()
+    private val inverse = Matrix()
+
+    fun updateMatrix(newMatrix: Matrix) {
+        matrix.set(newMatrix)
+        matrix.invert(inverse)
+        invalidate()
+    }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
         if (!drawingEnabled) return false
+        val pts = floatArrayOf(event.x, event.y)
+        inverse.mapPoints(pts)
         when (event.action) {
-            MotionEvent.ACTION_DOWN -> path.moveTo(event.x, event.y)
-            MotionEvent.ACTION_MOVE -> path.lineTo(event.x, event.y)
+            MotionEvent.ACTION_DOWN -> path.moveTo(pts[0], pts[1])
+            MotionEvent.ACTION_MOVE -> path.lineTo(pts[0], pts[1])
         }
         invalidate()
         return true
@@ -40,7 +51,10 @@ class AnnotationView @JvmOverloads constructor(
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
+        canvas.save()
+        canvas.concat(matrix)
         canvas.drawPath(path, paint)
+        canvas.restore()
     }
 
     /**

--- a/app/src/main/java/com/example/codexpdfone/ui/PdfAdapter.kt
+++ b/app/src/main/java/com/example/codexpdfone/ui/PdfAdapter.kt
@@ -1,0 +1,46 @@
+package com.example.codexpdfone.ui
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import android.graphics.pdf.PdfRenderer
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+
+private const val SCALE = 2f
+
+/**
+ * RecyclerView adapter that renders PDF pages into [PdfPageView].
+ */
+class PdfAdapter(private val pages: List<PdfPage>): RecyclerView.Adapter<PdfAdapter.PageHolder>() {
+
+    class PageHolder(val pageView: PdfPageView): RecyclerView.ViewHolder(pageView)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PageHolder {
+        val view = PdfPageView(parent.context)
+        view.layoutParams = RecyclerView.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.WRAP_CONTENT
+        )
+        view.enableDrawing(true)
+        return PageHolder(view)
+    }
+
+    override fun getItemCount() = pages.size
+
+    override fun onBindViewHolder(holder: PageHolder, position: Int) {
+        val desc = pages[position]
+        val page = desc.renderer.openPage(desc.index)
+        val width = (page.width * SCALE).toInt()
+        val height = (page.height * SCALE).toInt()
+        val bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
+        val rect = Rect(0, 0, width, height)
+        page.render(bitmap, rect, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
+        page.close()
+        holder.pageView.setBitmap(bitmap)
+    }
+}
+
+/**
+ * Simple descriptor for a PDF page belonging to a [PdfRenderer].
+ */
+data class PdfPage(val renderer: PdfRenderer, val index: Int)

--- a/app/src/main/java/com/example/codexpdfone/ui/PdfPageView.kt
+++ b/app/src/main/java/com/example/codexpdfone/ui/PdfPageView.kt
@@ -1,0 +1,42 @@
+package com.example.codexpdfone.ui
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import com.github.chrisbanes.photoview.PhotoView
+
+/**
+ * View combining a PhotoView for PDF page rendering and an AnnotationView
+ * that is scaled together with the PhotoView matrix.
+ */
+class PdfPageView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val photoView = PhotoView(context)
+    private val annotationView = AnnotationView(context)
+
+    init {
+        addView(photoView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
+        addView(annotationView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+        photoView.setOnMatrixChangeListener {
+            annotationView.updateMatrix(photoView.imageMatrix)
+        }
+    }
+
+    fun setBitmap(bitmap: Bitmap) {
+        photoView.setImageBitmap(bitmap)
+        annotationView.updateMatrix(photoView.imageMatrix)
+    }
+
+    fun enableDrawing(enabled: Boolean) {
+        annotationView.drawingEnabled = enabled
+    }
+
+    fun clearAnnotations() {
+        annotationView.clearAnnotations()
+    }
+}

--- a/app/src/main/res/layout/activity_pdf.xml
+++ b/app/src/main/res/layout/activity_pdf.xml
@@ -1,18 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/pdfRecyclerView"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-
-    <com.github.chrisbanes.photoview.PhotoView
-        android:id="@+id/pdfImage"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:adjustViewBounds="true" />
-
-
-    <com.example.codexpdfone.ui.AnnotationView
-        android:id="@+id/annotationView"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</FrameLayout>
+    android:layout_height="match_parent" />


### PR DESCRIPTION
## Summary
- show PDF pages from all bundled PDFs
- allow scrolling through pages with RecyclerView
- keep annotation overlay scaled with pinch zoom

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68605bc04024832da0ff61a16bbdd5df