### PR TITLE
Add image overlay and switch to ViewPager2

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -39,8 +39,9 @@ dependencies {
     implementation(libs.material)
     implementation(libs.androidx.activity)
     implementation(libs.androidx.constraintlayout)
+    implementation(libs.androidx.viewpager2)
     // PDF libraries for rendering and editing
-    implementation ("com.github.chrisbanes:PhotoView:2.3.0")
+    implementation(libs.photo.view)
 
     implementation(libs.pdfbox.android)
     testImplementation(libs.junit)

--- a/app/src/main/java/com/example/codexpdfone/PdfActivity.kt
+++ b/app/src/main/java/com/example/codexpdfone/PdfActivity.kt
@@ -5,10 +5,11 @@ import android.os.ParcelFileDescriptor
 import android.graphics.pdf.PdfRenderer
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.floatingactionbutton.FloatingActionButton
 import com.example.codexpdfone.ui.PdfAdapter
 import com.example.codexpdfone.ui.PdfPage
+import android.graphics.BitmapFactory
 import java.io.File
 import java.io.FileOutputStream
 
@@ -20,14 +21,14 @@ class PdfActivity : AppCompatActivity() {
 
     private val renderers = mutableListOf<PdfRenderer>()
     private val pages = mutableListOf<PdfPage>()
+    private lateinit var adapter: PdfAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContentView(R.layout.activity_pdf)
 
-        val recycler = findViewById<RecyclerView>(R.id.pdfRecyclerView)
-        recycler.layoutManager = LinearLayoutManager(this)
+        val pager = findViewById<ViewPager2>(R.id.pdfViewPager)
 
         // Load all PDF assets and collect their pages
         val assetPdfs = assets.list("")?.filter { it.endsWith(".pdf") } ?: emptyList()
@@ -48,7 +49,18 @@ class PdfActivity : AppCompatActivity() {
             }
         }
 
-        recycler.adapter = PdfAdapter(pages)
+        adapter = PdfAdapter(pages)
+        pager.adapter = adapter
+        pager.orientation = ViewPager2.ORIENTATION_VERTICAL
+
+        val addFab = findViewById<FloatingActionButton>(R.id.addImageFab)
+        addFab.setOnClickListener {
+            val bitmap = BitmapFactory.decodeResource(
+                resources,
+                R.drawable.ic_launcher_foreground
+            )
+            adapter.addImage(pager.currentItem, bitmap)
+        }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/example/codexpdfone/ui/AnnotationView.kt
+++ b/app/src/main/java/com/example/codexpdfone/ui/AnnotationView.kt
@@ -42,8 +42,13 @@ class AnnotationView @JvmOverloads constructor(
         val pts = floatArrayOf(event.x, event.y)
         inverse.mapPoints(pts)
         when (event.action) {
-            MotionEvent.ACTION_DOWN -> path.moveTo(pts[0], pts[1])
+            MotionEvent.ACTION_DOWN -> {
+                path.moveTo(pts[0], pts[1])
+                parent.requestDisallowInterceptTouchEvent(true)
+            }
             MotionEvent.ACTION_MOVE -> path.lineTo(pts[0], pts[1])
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL ->
+                parent.requestDisallowInterceptTouchEvent(false)
         }
         invalidate()
         return true

--- a/app/src/main/java/com/example/codexpdfone/ui/ImageLayer.kt
+++ b/app/src/main/java/com/example/codexpdfone/ui/ImageLayer.kt
@@ -1,0 +1,93 @@
+package com.example.codexpdfone.ui
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.view.View
+
+/**
+ * View that draws bitmaps over the PDF and allows moving and removing them.
+ */
+class ImageLayer @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : View(context, attrs, defStyleAttr) {
+
+    private val images = mutableListOf<ImageItem>()
+    private val matrix = Matrix()
+    private val inverse = Matrix()
+
+    private var active: ImageItem? = null
+    private var lastX = 0f
+    private var lastY = 0f
+
+    data class ImageItem(val bitmap: Bitmap, var x: Float, var y: Float)
+
+    fun updateMatrix(newMatrix: Matrix) {
+        matrix.set(newMatrix)
+        matrix.invert(inverse)
+        invalidate()
+    }
+
+    fun addImage(bitmap: Bitmap) {
+        images.add(ImageItem(bitmap, 0f, 0f))
+        invalidate()
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        val pts = floatArrayOf(event.x, event.y)
+        inverse.mapPoints(pts)
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> {
+                active = images.lastOrNull { item ->
+                    pts[0] >= item.x && pts[0] <= item.x + item.bitmap.width &&
+                            pts[1] >= item.y && pts[1] <= item.y + item.bitmap.height
+                }
+                if (active != null) {
+                    lastX = pts[0]
+                    lastY = pts[1]
+                    parent.requestDisallowInterceptTouchEvent(true)
+                    return true
+                }
+            }
+            MotionEvent.ACTION_MOVE -> {
+                active?.let { item ->
+                    val dx = pts[0] - lastX
+                    val dy = pts[1] - lastY
+                    item.x += dx
+                    item.y += dy
+                    lastX = pts[0]
+                    lastY = pts[1]
+                    invalidate()
+                    return true
+                }
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                active?.let { item ->
+                    if (event.eventTime - event.downTime > 800) {
+                        images.remove(item)
+                    }
+                }
+                active = null
+                parent.requestDisallowInterceptTouchEvent(false)
+                invalidate()
+                return active != null
+            }
+        }
+        return false
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        canvas.save()
+        canvas.concat(matrix)
+        for (item in images) {
+            canvas.drawBitmap(item.bitmap, item.x, item.y, null)
+        }
+        canvas.restore()
+    }
+}

--- a/app/src/main/java/com/example/codexpdfone/ui/PdfAdapter.kt
+++ b/app/src/main/java/com/example/codexpdfone/ui/PdfAdapter.kt
@@ -13,7 +13,11 @@ private const val SCALE = 2f
  */
 class PdfAdapter(private val pages: List<PdfPage>): RecyclerView.Adapter<PdfAdapter.PageHolder>() {
 
-    class PageHolder(val pageView: PdfPageView): RecyclerView.ViewHolder(pageView)
+    class PageHolder(val pageView: PdfPageView): RecyclerView.ViewHolder(pageView) {
+        var index: Int = -1
+    }
+
+    private val holders = mutableMapOf<Int, PageHolder>()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PageHolder {
         val view = PdfPageView(parent.context)
@@ -29,6 +33,7 @@ class PdfAdapter(private val pages: List<PdfPage>): RecyclerView.Adapter<PdfAdap
 
     override fun onBindViewHolder(holder: PageHolder, position: Int) {
         val desc = pages[position]
+        holder.index = position
         val page = desc.renderer.openPage(desc.index)
         val width = (page.width * SCALE).toInt()
         val height = (page.height * SCALE).toInt()
@@ -37,6 +42,16 @@ class PdfAdapter(private val pages: List<PdfPage>): RecyclerView.Adapter<PdfAdap
         page.render(bitmap, rect, null, PdfRenderer.Page.RENDER_MODE_FOR_DISPLAY)
         page.close()
         holder.pageView.setBitmap(bitmap)
+        holders[position] = holder
+    }
+
+    override fun onViewRecycled(holder: PageHolder) {
+        holders.entries.removeIf { it.value == holder }
+        super.onViewRecycled(holder)
+    }
+
+    fun addImage(position: Int, bitmap: Bitmap) {
+        holders[position]?.pageView?.addImage(bitmap)
     }
 }
 

--- a/app/src/main/java/com/example/codexpdfone/ui/PdfPageView.kt
+++ b/app/src/main/java/com/example/codexpdfone/ui/PdfPageView.kt
@@ -18,12 +18,15 @@ class PdfPageView @JvmOverloads constructor(
 
     private val photoView = PhotoView(context)
     private val annotationView = AnnotationView(context)
+    private val imageLayer = ImageLayer(context)
 
     init {
         addView(photoView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT))
         addView(annotationView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
+        addView(imageLayer, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
         photoView.setOnMatrixChangeListener {
             annotationView.updateMatrix(photoView.imageMatrix)
+            imageLayer.updateMatrix(photoView.imageMatrix)
         }
     }
 
@@ -38,5 +41,9 @@ class PdfPageView @JvmOverloads constructor(
 
     fun clearAnnotations() {
         annotationView.clearAnnotations()
+    }
+
+    fun addImage(bitmap: Bitmap) {
+        imageLayer.addImage(bitmap)
     }
 }

--- a/app/src/main/res/layout/activity_pdf.xml
+++ b/app/src/main/res/layout/activity_pdf.xml
@@ -1,5 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.recyclerview.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/pdfRecyclerView"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" />
+    android:layout_height="match_parent">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/pdfViewPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/addImageFab"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@android:drawable/ic_menu_gallery"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp" />
+
+</FrameLayout>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ activity = "1.10.1"
 constraintlayout = "2.2.1"
 pdfboxAndroid = "2.0.27.0"
 photoView = "2.3.0"
+viewpager2 = "1.1.0-beta01"
 
 
 [libraries]
@@ -24,6 +25,7 @@ androidx-activity = { group = "androidx.activity", name = "activity", version.re
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 pdfbox-android = { group = "com.tom-roush", name = "pdfbox-android", version.ref = "pdfboxAndroid" }
 photo-view = { group = "com.github.chrisbanes", name = "photoview", version.ref = "photoView" }
+androidx-viewpager2 = { group = "androidx.viewpager2", name = "viewpager2", version.ref = "viewpager2" }
 
 
 [plugins]


### PR DESCRIPTION
## Summary
- use ViewPager2 instead of RecyclerView in `PdfActivity`
- add a floating action button for inserting images
- prevent scrolling when drawing annotations
- support movable image overlays on each PDF page
- update build to include ViewPager2

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68611e8a6868832d87cad975b86a8e88